### PR TITLE
WIP: Emacs tags support

### DIFF
--- a/identify/emacs_tags.py
+++ b/identify/emacs_tags.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+EMACS_TAGS = {
+    'sh': {'shell', 'sh'},
+    'shell-script': {'shell', 'sh'},
+    'cperl': {'perl'},
+    'perl': {'perl'},
+    'python': {'python'},
+    # TODO a lot mode
+}


### PR DESCRIPTION
Here go first steps towards Emacs tags support. These are strings like `-*- shell-script -*-` that are fairly commonly found in files here and there.

Not quite complete yet, but filing the PR already now for an ack that this would be a desirable addition and comments.

This looks at the couple of first lines of files only, even though IIRC the tags can be located pretty much anywhere in a file. It's common for them to be at beginning of files though.