### PR TITLE
Identify can now detect python packages

### DIFF
--- a/identify/identify.py
+++ b/identify/identify.py
@@ -18,6 +18,7 @@ from identify.vendor import licenses
 printable = frozenset(string.printable)
 
 DIRECTORY = 'directory'
+PYTHON_PACKAGE = 'python-package'
 SYMLINK = 'symlink'
 FILE = 'file'
 EXECUTABLE = 'executable'
@@ -37,7 +38,10 @@ def tags_from_path(path):
     if not os.path.lexists(path):
         raise ValueError('{} does not exist.'.format(path))
     if os.path.isdir(path):
-        return {DIRECTORY}
+        tags = {DIRECTORY}
+        if os.path.isfile(os.path.join(path, '__init__.py')):
+            tags.add(PYTHON_PACKAGE)
+        return tags
     if os.path.islink(path):
         return {SYMLINK}
 

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -35,6 +35,16 @@ def test_tags_from_path_directory(tmpdir):
     assert identify.tags_from_path(x.strpath) == {'directory'}
 
 
+def test_tags_from_path_package(tmpdir):
+    x = tmpdir.join('foo')
+    x.mkdir()
+    init_path = x.join('__init__.py')
+    init_path.write('', mode='w')
+    assert identify.tags_from_path(x.strpath) == {
+        'directory', 'python-package',
+    }
+
+
 def test_tags_from_path_symlink(tmpdir):
     x = tmpdir.join('foo')
     x.mksymlinkto(tmpdir.join('lol').ensure())


### PR DESCRIPTION
This is useful in order to determine whether a directory should be evaluated or not.