### PR TITLE
Adds support for Arch Linux packaging description files

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -257,6 +257,7 @@ NAMES = {
     'PATENTS': EXTENSIONS['txt'],
     'Pipfile': EXTENSIONS['toml'],
     'Pipfile.lock': EXTENSIONS['json'],
+    'PKGBUILD': {'text', 'bash', 'pkgbuild', 'alpm'},
     'README': EXTENSIONS['txt'],
     'Rakefile': EXTENSIONS['rb'],
     'setup.cfg': EXTENSIONS['ini'],


### PR DESCRIPTION
Adds support for `PKGBUILD` and `*.install` files. Both are interpreted as bash by the Arch Linux packaging toolchain (`makepkg` and `pacman`) but do not use shebangs or common bash file extensions.

Reference: https://www.archlinux.org/pacman/PKGBUILD.5.html