### PR TITLE
Add .myst files to extensions.py

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -111,6 +111,7 @@ EXTENSIONS = {
     'mli': {'text', 'ocaml'},
     'mm': {'text', 'c++', 'objective-c++'},
     'modulemap': {'text', 'modulemap'},
+    'myst': {'text', 'myst'},
     'ngdoc': {'text', 'ngdoc'},
     'nim': {'text', 'nim'},
     'nims': {'text', 'nim'},


### PR DESCRIPTION
Closes #162 . Adds markedly structured test as a supported extension (myst).