### PR TITLE
Add '.rake' extension as a Ruby file

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -145,6 +145,7 @@ EXTENSIONS = {
     'pyz': {'binary', 'pyz'},
     'pyzw': {'binary', 'pyz'},
     'r': {'text', 'r'},
+    'rake': {'text', 'ruby'},
     'rb': {'text', 'ruby'},
     'rs': {'text', 'rust'},
     'rst': {'text', 'rst'},


### PR DESCRIPTION
The '.rake' extension is used to break large Rakefiles into smaller
files. Rakefiles are Ruby files.

https://ruby.github.io/rake/doc/rakefile_rdoc.html#label-Multiple+Rake+Files

> Multiple Rake Files
>
> Not all tasks need to be included in a single Rakefile. Additional
> rake files (with the file extension “.rake”) may be placed in rakelib
> directory located at the top level of a project (i.e. the same
> directory that contains the main Rakefile).
>
> Also, rails projects may include additional rake files in the
> lib/tasks directory.