### PR TITLE
Add support for .clang-tidy and .clang-format

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -231,6 +231,8 @@ NAMES = {
     '.bashrc': EXTENSIONS['bash'],
     '.bowerrc': EXTENSIONS['json'] | {'bowerrc'},
     '.browserslistrc': {'text', 'browserslistrc'},
+    '.clang-format': EXTENSIONS['yaml'],
+    '.clang-tidy': EXTENSIONS['yaml'],
     '.codespellrc': EXTENSIONS['ini'] | {'codespellrc'},
     '.coveragerc': EXTENSIONS['ini'] | {'coveragerc'},
     '.cshrc': EXTENSIONS['csh'],


### PR DESCRIPTION
These two config files are very common for C++ commit hooks and are yaml formats. It would be great if they were properly support so hooks like check-yaml would recognize them.