### PR TITLE
Add global constants to classify tags by type

### DIFF
--- a/identify/identify.py
+++ b/identify/identify.py
@@ -25,7 +25,10 @@ NON_EXECUTABLE = 'non-executable'
 TEXT = 'text'
 BINARY = 'binary'
 
-ALL_TAGS = {DIRECTORY, SYMLINK, FILE, EXECUTABLE, NON_EXECUTABLE, TEXT, BINARY}
+TYPE_TAGS = frozenset((DIRECTORY, FILE, SYMLINK))
+MODE_TAGS = frozenset((EXECUTABLE, NON_EXECUTABLE))
+ENCODING_TAGS = frozenset((BINARY, TEXT))
+ALL_TAGS = {*TYPE_TAGS, *MODE_TAGS, *ENCODING_TAGS}
 ALL_TAGS.update(*extensions.EXTENSIONS.values())
 ALL_TAGS.update(*extensions.EXTENSIONS_NEED_BINARY_CHECK.values())
 ALL_TAGS.update(*extensions.NAMES.values())
@@ -62,14 +65,14 @@ def tags_from_path(path):
 
     # some extensions can be both binary and text
     # see EXTENSIONS_NEED_BINARY_CHECK
-    if not {TEXT, BINARY} & tags:
+    if not ENCODING_TAGS & tags:
         if file_is_text(path):
             tags.add(TEXT)
         else:
             tags.add(BINARY)
 
-    assert {TEXT, BINARY} & tags, tags
-    assert {EXECUTABLE, NON_EXECUTABLE} & tags, tags
+    assert ENCODING_TAGS & tags, tags
+    assert MODE_TAGS & tags, tags
     return tags
 
 

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -14,6 +14,20 @@ from identify import identify
 def test_all_tags_includes_basic_ones():
     assert 'file' in identify.ALL_TAGS
     assert 'directory' in identify.ALL_TAGS
+    assert 'executable' in identify.ALL_TAGS
+    assert 'text' in identify.ALL_TAGS
+
+
+@pytest.mark.parametrize(
+    'tag_group',
+    (
+        identify.TYPE_TAGS,
+        identify.MODE_TAGS,
+        identify.ENCODING_TAGS,
+    ),
+)
+def test_all_tags_contains_all_groups(tag_group):
+    assert tag_group < identify.ALL_TAGS
 
 
 def test_all_tags_contains_each_type():


### PR DESCRIPTION
Per the (lengthy) discussion in #157 , implements the proposed global constants to classify tags by type, making the code and tests slightly simpler and more robust, and enabling external tools consuming them to differentiate between tag types without resorting to hardcoding.

Also adds a test that all tags from each group are included in the list of all tags, and expands the existing basic tags test to at least one tag from each group.

I'm happy to change the names chosen for the constants if the currently selected ones are problematic, just let me know, thanks!

Resolves #157 