### PR TITLE
Fix frozenset usage, not compatible with Python2.7

### DIFF
--- a/identify/identify.py
+++ b/identify/identify.py
@@ -28,7 +28,7 @@ BINARY = 'binary'
 TYPE_TAGS = frozenset((DIRECTORY, FILE, SYMLINK))
 MODE_TAGS = frozenset((EXECUTABLE, NON_EXECUTABLE))
 ENCODING_TAGS = frozenset((BINARY, TEXT))
-ALL_TAGS = {*TYPE_TAGS, *MODE_TAGS, *ENCODING_TAGS}
+ALL_TAGS = set(TYPE_TAGS).union(MODE_TAGS).union(ENCODING_TAGS)
 ALL_TAGS.update(*extensions.EXTENSIONS.values())
 ALL_TAGS.update(*extensions.EXTENSIONS_NEED_BINARY_CHECK.values())
 ALL_TAGS.update(*extensions.NAMES.values())


### PR DESCRIPTION
linter in Python 2.7 is failing because how it uses frozenset
```
  File "/home/circleci/project/venv/lib/python2.7/site-packages/identify/identify.py", line 31
    ALL_TAGS = {*TYPE_TAGS, *MODE_TAGS, *ENCODING_TAGS}
                ^
SyntaxError: invalid syntax
```
