### PR TITLE
List Gemfile.lock as type 'text'

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -261,6 +261,7 @@ NAMES = {
     'COPYING': EXTENSIONS['txt'],
     'Dockerfile': {'text', 'dockerfile'},
     'Gemfile': EXTENSIONS['rb'],
+    'Gemfile.lock': {'text'},
     'Jenkinsfile': {'text', 'groovy'},
     'LICENSE': EXTENSIONS['txt'],
     'MAINTAINERS': EXTENSIONS['txt'],

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -158,6 +158,8 @@ def test_tags_from_path_plist_text(tmpdir):
         ('Pipfile.lock', {'text', 'json'}),
         ('mod/test.py', {'text', 'python'}),
         ('mod/Dockerfile', {'text', 'dockerfile'}),
+        ('Gemfile', {'text', 'ruby'}),
+        ('Gemfile.lock', {'text'}),
 
         # does not set binary / text
         ('f.plist', {'plist'}),


### PR DESCRIPTION
To avoid it being treated as ruby code (e.g. via pre-commit running tools like rubocop).

---

I'm not super confident about this as I don't work much in ruby, but my understanding of `Gemfile.lock` is that it's its own format and not ruby code (vs, for example, `Gemfile`). I started looking at `identify` because my pre-commit config is running rubocop on `Gemfile.lock` and blowing up.

I confirmed with `identify-cli` that this removes the ruby tag.

I'm guessing that somehow the content-based detection is treating my `Gemfile.lock` as ruby? I don't know what the explanation could be other than that.

If I'm wrong about how to handle this, please educate me! 😄 