### PR TITLE
Add .dll as a binary file

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -32,6 +32,7 @@ EXTENSIONS = {
     'cxx': {'text', 'c++'},
     'dart': {'text', 'dart'},
     'def': {'text', 'def'},
+    'dll': {'binary'},
     'dtd': {'text', 'dtd'},
     'ear': {'binary', 'zip', 'jar'},
     'edn': {'text', 'clojure', 'edn'},


### PR DESCRIPTION
I have a few binary test vectors that pre-commit wants to mess up, calling those .bin seems like pretty solid solution. 

Also, .exe exists, .dll is a very close cousin