### PR TITLE
fix: checking for executable file regardless containerization

### DIFF
--- a/identify/identify.py
+++ b/identify/identify.py
@@ -1,5 +1,5 @@
 import errno
-import os.path
+import os
 import re
 import shlex
 import stat
@@ -54,7 +54,8 @@ def tags_from_path(path: str) -> Set[str]:
 
     tags = {FILE}
 
-    executable = os.access(path, os.X_OK)
+    executable = os.stat(path).st_mode \
+        & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     if executable:
         tags.add(EXECUTABLE)
     else:


### PR DESCRIPTION
- relates to pre-commit/pre-commit-hooks#528

for more information, see docker/for-mac#5029