### PR TITLE
propose adding Qt `ui` file as xml

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -185,6 +185,7 @@ EXTENSIONS = {
     'twig': {'text', 'twig'},
     'txsprofile': {'text', 'ini', 'txsprofile'},
     'txt': {'text', 'plain-text'},
+    'ui': {'text', 'xml'},
     'v': {'text', 'verilog'},
     'vb': {'text', 'vb'},
     'vbproj': {'text', 'xml', 'vbproj'},


### PR DESCRIPTION
Some projects using the Qt framework rely on `.xml` files that define UI layouts.
More [info on the format here](https://doc.qt.io/qtforpython/tutorials/basictutorial/uifiles.html).

On the topic of Qt, there's also [`.qrc`](https://doc.qt.io/qt-5/resources.html) and possibly others, probably for a different MR though.