### PR TITLE
bats file extension added

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -6,6 +6,7 @@ EXTENSIONS = {
     'avif': {'binary', 'image', 'avif'},
     'bash': {'text', 'shell', 'bash'},
     'bat': {'text', 'batch'},
+    'bats': {'text', 'shell', 'bash', 'bats'},
     'bib': {'text', 'bib'},
     'bmp': {'binary', 'image', 'bitmap'},
     'bz2': {'binary', 'bzip2'},


### PR DESCRIPTION
bats is a TAP-compliant testing framework [1]. However, .bats file are bash and shellcheck compatible.

Recognising this files as bash will help them to test with shellcheck

https://github.com/bats-core/