### PR TITLE
add adobe illustrator's .ai extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -1,5 +1,6 @@
 EXTENSIONS = {
     'adoc': {'text', 'asciidoc'},
+    'ai': {'binary', 'adobe-illustrator'},
     'asciidoc': {'text', 'asciidoc'},
     'apinotes': {'text', 'apinotes'},
     'asar': {'binary', 'asar'},


### PR DESCRIPTION
Fixes #223. 

With this change .ai files are detected as:

```bash
$ identify-cli red_square_blue_circle.ai
["adobe-illustrator", "binary", "file", "non-executable"]
```