### PR TITLE
Add powershell .ps1 extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -138,6 +138,7 @@ EXTENSIONS = {
     'pp': {'text', 'puppet'},
     'properties': {'text', 'java-properties'},
     'proto': {'text', 'proto'},
+    'ps1': {'text', 'powershell'},
     'puml': {'text', 'plantuml'},
     'purs': {'text', 'purescript'},
     'pxd': {'text', 'cython'},


### PR DESCRIPTION
With this change, powershell `.ps1` extensions are identified as:
```
$ identify-cli.exe .\download_cats.ps1
["executable", "file", "powershell", "text"]
```