### PR TITLE
add hcl extension support

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -62,6 +62,7 @@ EXTENSIONS = {
     'gypi': {'text', 'gyp', 'python'},
     'gz': {'binary', 'gzip'},
     'h': {'text', 'header', 'c', 'c++'},
+    'hcl': {'text', 'hcl'},
     'hh': {'text', 'header', 'c++'},
     'hpp': {'text', 'header', 'c++'},
     'hs': {'text', 'haskell'},


### PR DESCRIPTION
## changes

- add `hcl` extension support
    - this is used by most Hashicorp tools, including `consul`, `packer`, and `vault` to name a few
    - <https://github.com/hashicorp/hcl>
- alphabetize `EXTENSIONS` keys
    - they were mostly there already, but a few weren't quite right