### PR TITLE
Add prisma extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -137,6 +137,7 @@ EXTENSIONS = {
     'png': {'binary', 'image', 'png'},
     'po': {'text', 'pofile'},
     'pp': {'text', 'puppet'},
+    'prisma': {'text', 'prisma'},
     'properties': {'text', 'java-properties'},
     'proto': {'text', 'proto'},
     'ps1': {'text', 'powershell'},


### PR DESCRIPTION
`.prisma` files (usally `schema.prisma`) are used for defining schema in [prisma](https://www.prisma.io/). Adding this extension would be useful for formatting the schema files using prettier with prisma plugin.