### PR TITLE
Add RELAX NG (.rng) to extensions

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -154,6 +154,7 @@ EXTENSIONS = {
     'r': {'text', 'r'},
     'rake': {'text', 'ruby'},
     'rb': {'text', 'ruby'},
+    'rng': {'text', 'xml', 'relax-ng'},
     'rs': {'text', 'rust'},
     'rst': {'text', 'rst'},
     's': {'text', 'asm'},


### PR DESCRIPTION
This adds RELAX NG schema files (https://relaxng.org/) to the extensions file, under the type `relax-ng`, but they're also `xml` files (and hence `text` files).

I don't know much about how commonly this is used or if .rng is used for any other types of files (I have just one such schema in one of my personal projects), but I did a quick Google search and it seems like the other major file type that uses the .rng extension is Nokia phone ringtones, which I'm guessing won't be an issue in practice for projects that use pre-commit.