### PR TITLE
Add vtl extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -205,6 +205,7 @@ EXTENSIONS = {
     'vh': {'text', 'verilog'},
     'vhd': {'text', 'vhdl'},
     'vim': {'text', 'vim'},
+    'vtl': {'text', 'vtl'},
     'vue': {'text', 'vue'},
     'war': {'binary', 'zip', 'jar'},
     'wav': {'binary', 'audio', 'wav'},


### PR DESCRIPTION
`.vtl` is used for [velocity](https://velocity.apache.org/) templates. vtl templates are used for aws [appsync resolvers](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-programming-guide.html#aws-appsync-resolver-mapping-template-reference-programming-guide).