### PR TITLE
add geojson extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -50,6 +50,7 @@ EXTENSIONS = {
     'fish': {'text', 'fish'},
     'gd': {'text', 'gdscript'},
     'gemspec': {'text', 'ruby'},
+    'geojson': {'text', 'geojson', 'json'},
     'gif': {'binary', 'image', 'gif'},
     'go': {'text', 'go'},
     'gotmpl': {'text', 'gotmpl'},


### PR DESCRIPTION
adding the `.geojson` file extension, which is basically just a regular `json` file, simply adding standardized field names and geospatial information in a specific order inside array.  being able to check it with `check-json`would be nice.

- more info: https://geojson.org/
- the rfc: https://datatracker.ietf.org/doc/html/rfc7946

<details>
 <summary>example file</summary>

```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [
              -112.763671875,
              41.77131167976407
            ],
            [
              -111.4453125,
              35.817813158696616
            ],
            [
              -103.095703125,
              33.7243396617476
            ],
            [
              -95.97656249999999,
              40.3130432088809
            ],
            [
              -106.435546875,
              44.902577996288876
            ],
            [
              -112.763671875,
              41.77131167976407
            ]
          ]
        ]
      }
    },
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Point",
        "coordinates": [
          -105.908203125,
          39.842286020743394
        ]
      }
    }
  ]
}
```
</details>


... not sure about the ordering in the `extensions.py` file. This is alphabetic now, but below `.json` would also make sense, since it's just an alias.