### PR TITLE
Add support for aspectj file extension.

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -1,6 +1,7 @@
 EXTENSIONS = {
     'adoc': {'text', 'asciidoc'},
     'ai': {'binary', 'adobe-illustrator'},
+    'aj': {'text', 'aspectj'},
     'asciidoc': {'text', 'asciidoc'},
     'apinotes': {'text', 'apinotes'},
     'asar': {'binary', 'asar'},


### PR DESCRIPTION
I discovered this extension was missing when I tried to use it with my pre-commit script.
[AspectJ](https://www.eclipse.org/aspectj/) can be used in two ways:

1. Using normal `.java` classes with annotations
2. Using the `.aj` extension with its own syntax

This pull-request adds support for the latter.