### PR TITLE
go.mod and go.sum are now detected as golang

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -288,6 +288,8 @@ NAMES = {
     'Gemfile': EXTENSIONS['rb'],
     'Gemfile.lock': {'text'},
     'GNUmakefile': EXTENSIONS['mk'],
+    'go.mod': {'text', 'go-mod'},
+    'go.sum': {'text', 'go-sum'},
     'Jenkinsfile': EXTENSIONS['jenkins'],
     'LICENSE': EXTENSIONS['txt'],
     'MAINTAINERS': EXTENSIONS['txt'],


### PR DESCRIPTION
go.mod and go.sum are used to define module dependencies and checksums in golang.

adding these two files to the list of known extensions/files.

﻿Signed-off-by: Frederick F. Kautz IV <fkautz@alumni.cmu.edu>
