### PR TITLE
use ukkonen cutoff on edit distance to improve performance

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ console_scripts =
 
 [options.extras_require]
 license =
-    editdistance-s
+    ukkonen
 
 [bdist_wheel]
 universal = True


### PR DESCRIPTION
resolves #251

### before

(using `https://git.launchpad.net/lpcraft`)

```console
$ time setup-cfg-fmt setup.cfg 

real	0m5.625s
user	0m5.612s
sys	0m0.012s
```

### after

```console
$ time setup-cfg-fmt setup.cfg 

real	0m0.096s
user	0m0.088s
sys	0m0.008s
```

