### PR TITLE
Add .prettierignore extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -269,7 +269,7 @@ NAMES = {
     '.mention-bot': EXTENSIONS['json'] | {'mention-bot'},
     '.npmignore': {'text', 'npmignore'},
     '.pdbrc': EXTENSIONS['py'] | {'pdbrc'},
-    '.prettierignore': {'text', 'gitignore'},
+    '.prettierignore': {'text', 'gitignore', 'prettierignore'},
     '.pypirc': EXTENSIONS['ini'] | {'pypirc'},
     '.rstcheck.cfg': EXTENSIONS['ini'],
     '.yamllint': EXTENSIONS['yaml'] | {'yamllint'},

--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -269,6 +269,7 @@ NAMES = {
     '.mention-bot': EXTENSIONS['json'] | {'mention-bot'},
     '.npmignore': {'text', 'npmignore'},
     '.pdbrc': EXTENSIONS['py'] | {'pdbrc'},
+    '.prettierignore': {'text', 'gitignore'},
     '.pypirc': EXTENSIONS['ini'] | {'pypirc'},
     '.rstcheck.cfg': EXTENSIONS['ini'],
     '.yamllint': EXTENSIONS['yaml'] | {'yamllint'},


### PR DESCRIPTION
From https://prettier.io/docs/en/ignore.html#ignoring-files-prettierignore:

> .prettierignore uses gitignore syntax.
