### PR TITLE
Add mjs as JavaScript file extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -113,6 +113,7 @@ EXTENSIONS = {
     'md': {'text', 'markdown'},
     'mdx': {'text', 'mdx'},
     'mib': {'text', 'mib'},
+    'mjs': {'text', 'javascript'},
     'mk': {'text', 'makefile'},
     'ml': {'text', 'ocaml'},
     'mli': {'text', 'ocaml'},


### PR DESCRIPTION
`.mjs` is the extension recommended for JavaScript modules by the V8 docs: https://v8.dev/features/modules#mjs , and the extension is used by other tools like Babel.