### PR TITLE
Add ino as a c++ file extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -78,6 +78,7 @@ EXTENSIONS = {
     'idr': {'text', 'idris'},
     'inc': {'text', 'inc'},
     'ini': {'text', 'ini'},
+    'ino': {'text', 'ino', 'c++'},
     'inx': {'text', 'xml', 'inx'},
     'ipynb': {'text', 'jupyter'},
     'j2': {'text', 'jinja'},


### PR DESCRIPTION
`.ino` is the extension used for [Arduino ](https://github.com/arduino/) Language [sketches](https://en.wikipedia.org/wiki/Arduino#Sketch).

The arduino language is a c++ variant, so it is useful to have the ability to utilise c++ formatters / linters.