### PR TITLE
add crystal extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -25,6 +25,7 @@ EXTENSIONS = {
     'coffee': {'text', 'coffee'},
     'conf': {'text'},
     'cpp': {'text', 'c++'},
+    'cr': {'text', 'crystal'},
     'crt': {'text', 'pem'},
     'cs': {'text', 'c#'},
     'csproj': {'text', 'xml', 'csproj'},


### PR DESCRIPTION
`.cr` extension is the [crystal lang] extension

Co-authored-by: Anthony Sottile <asottile@umich.edu>

[crystal lang]: https://crystal-lang.org/reference/1.3/using_the_compiler/index.html#creating-an-executable