### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:
@@ -38,7 +38,7 @@ repos:
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38]
+    toxenvs: [py37, py38]
     os: linux

--- a/bin/vendor-licenses
+++ b/bin/vendor-licenses
@@ -3,6 +3,8 @@
 
     ./bin/vendor-licenses > identify/vendor/licenses.py
 """
+from __future__ import annotations
+
 import argparse
 import os.path
 import subprocess

--- a/identify/cli.py
+++ b/identify/cli.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import argparse
 import json
-from typing import Optional
 from typing import Sequence
 
 from identify import identify
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--filename-only', action='store_true')
     parser.add_argument('path')

--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 EXTENSIONS = {
     'adoc': {'text', 'asciidoc'},
     'ai': {'binary', 'adobe-illustrator'},

--- a/identify/identify.py
+++ b/identify/identify.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import errno
 import math
 import os.path
@@ -7,10 +9,6 @@ import stat
 import string
 import sys
 from typing import IO
-from typing import List
-from typing import Optional
-from typing import Set
-from typing import Tuple
 
 from identify import extensions
 from identify import interpreters
@@ -39,7 +37,7 @@ _ALL_TAGS.update(*interpreters.INTERPRETERS.values())
 ALL_TAGS = frozenset(_ALL_TAGS)
 
 
-def tags_from_path(path: str) -> Set[str]:
+def tags_from_path(path: str) -> set[str]:
     try:
         sr = os.lstat(path)
     except (OSError, ValueError):  # same error-handling as `os.lexists()`
@@ -85,7 +83,7 @@ def tags_from_path(path: str) -> Set[str]:
     return tags
 
 
-def tags_from_filename(path: str) -> Set[str]:
+def tags_from_filename(path: str) -> set[str]:
     _, filename = os.path.split(path)
     _, ext = os.path.splitext(filename)
 
@@ -107,7 +105,7 @@ def tags_from_filename(path: str) -> Set[str]:
     return ret
 
 
-def tags_from_interpreter(interpreter: str) -> Set[str]:
+def tags_from_interpreter(interpreter: str) -> set[str]:
     _, _, interpreter = interpreter.rpartition('/')
 
     # Try "python3.5.2" => "python3.5" => "python3" until one matches.
@@ -141,7 +139,7 @@ def file_is_text(path: str) -> bool:
         return is_text(f)
 
 
-def _shebang_split(line: str) -> List[str]:
+def _shebang_split(line: str) -> list[str]:
     try:
         # shebangs aren't supposed to be quoted, though some tools such as
         # setuptools will write them with quotes so we'll best-guess parse
@@ -155,8 +153,8 @@ def _shebang_split(line: str) -> List[str]:
 
 def _parse_nix_shebang(
         bytesio: IO[bytes],
-        cmd: Tuple[str, ...],
-) -> Tuple[str, ...]:
+        cmd: tuple[str, ...],
+) -> tuple[str, ...]:
     while bytesio.read(2) == b'#!':
         next_line_b = bytesio.readline()
         try:
@@ -177,7 +175,7 @@ def _parse_nix_shebang(
     return cmd
 
 
-def parse_shebang(bytesio: IO[bytes]) -> Tuple[str, ...]:
+def parse_shebang(bytesio: IO[bytes]) -> tuple[str, ...]:
     """Parse the shebang from a file opened for reading binary."""
     if bytesio.read(2) != b'#!':
         return ()
@@ -204,7 +202,7 @@ def parse_shebang(bytesio: IO[bytes]) -> Tuple[str, ...]:
     return cmd
 
 
-def parse_shebang_from_file(path: str) -> Tuple[str, ...]:
+def parse_shebang_from_file(path: str) -> tuple[str, ...]:
     """Parse the shebang given a file path."""
     if not os.path.lexists(path):
         raise ValueError(f'{path} does not exist.')
@@ -231,7 +229,7 @@ def _norm_license(s: str) -> str:
     return s.strip()
 
 
-def license_id(filename: str) -> Optional[str]:
+def license_id(filename: str) -> str | None:
     """Return the spdx id for the license contained in `filename`.  If no
     license is detected, returns `None`.
 

--- a/identify/interpreters.py
+++ b/identify/interpreters.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 INTERPRETERS = {
     'ash': {'shell', 'ash'},
     'awk': {'awk'},

--- a/identify/vendor/licenses.py
+++ b/identify/vendor/licenses.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 LICENSES = (
     (
         '0BSD',

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -23,7 +22,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.packages.find]
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from identify import cli
 
 

--- a/tests/extensions_test.py
+++ b/tests/extensions_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from identify import extensions

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import builtins
 import errno
 import io

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,pypy3,pre-commit
+envlist = py37,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos