### PR TITLE
Adding `sty` files (normally TeX files)

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -178,6 +178,7 @@ EXTENSIONS = {
     'spec': {'text', 'spec'},
     'sql': {'text', 'sql'},
     'ss': {'text', 'scheme'},
+    'sty': {'text', 'tex'},
     'styl': {'text', 'stylus'},
     'sv': {'text', 'system-verilog'},
     'svelte': {'text', 'svelte'},


### PR DESCRIPTION
I was doubting to add a secondary entry `tex`, but I don't think this is justified. Some searching gave me also some non-TeX usage. 

Reference for usage with TeX: https://www.overleaf.com/learn/latex/Understanding_packages_and_class_files