### PR TITLE
Add `.liquid` extension for Liquid templates

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -108,6 +108,7 @@ EXTENSIONS = {
     'lhs': {'text', 'literate-haskell'},
     'libsonnet': {'text', 'jsonnet'},
     'lidr': {'text', 'idris'},
+    'liquid': {'text', 'liquid'},
     'lr': {'text', 'lektor'},
     'lua': {'text', 'lua'},
     'm': {'text', 'c', 'objective-c'},


### PR DESCRIPTION
[Liquid](https://github.com/Shopify/liquid) is used by Shopify, Jekyll, and a few other projects in the Ruby ecosystem. The `.liquid` extension isn’t mandatory but it’s very common (see for example [Shopify themes](https://shopify.dev/themes/architecture#directory-structure-and-component-types), where `.liquid` is mandated).