### PR TITLE
Add `.njk` extension for Nunjucks templates

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -129,6 +129,7 @@ EXTENSIONS = {
     'nims': {'text', 'nim'},
     'nimble': {'text', 'nimble'},
     'nix': {'text', 'nix'},
+    'njk': ('text', 'nunjucks'},
     'otf': {'binary', 'otf'},
     'p12': {'binary', 'p12'},
     'patch': {'text', 'diff'},

--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -129,7 +129,7 @@ EXTENSIONS = {
     'nims': {'text', 'nim'},
     'nimble': {'text', 'nimble'},
     'nix': {'text', 'nix'},
-    'njk': ('text', 'nunjucks'},
+    'njk': {'text', 'nunjucks'},
     'otf': {'binary', 'otf'},
     'p12': {'binary', 'p12'},
     'patch': {'text', 'diff'},


### PR DESCRIPTION
Nunjucks is a popular template engine in the Node world, for example with static site generators like [Eleventy](https://www.11ty.dev/docs/languages/nunjucks/). `.njk` is the most common extension for Nunjucks templates, and is [mentioned in the official documentation](https://mozilla.github.io/nunjucks/templating.html#file-extensions).