### PR TITLE
Add `.hbs` extension for Handlebars templates

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -66,6 +66,7 @@ EXTENSIONS = {
     'gypi': {'text', 'gyp', 'python'},
     'gz': {'binary', 'gzip'},
     'h': {'text', 'header', 'c', 'c++'},
+    'hbs': {'text', 'handlebars'},
     'hcl': {'text', 'hcl'},
     'hh': {'text', 'header', 'c++'},
     'hpp': {'text', 'header', 'c++'},


### PR DESCRIPTION
[Handlebars](https://handlebarsjs.com/) templates most commonly use the `.hbs` extension. I believe [Ember](https://guides.emberjs.com/release/components/) is the most popular tool that uses `.hbs`. [Eleventy](https://www.11ty.dev/docs/languages/handlebars/) is another example.