### PR TITLE
Add cjs as a JavaScript file extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -18,6 +18,7 @@ EXTENSIONS = {
     'cc': {'text', 'c++'},
     'cfg': {'text'},
     'chs': {'text', 'c2hs'},
+    'cjs': {'text', 'javascript'},
     'clj': {'text', 'clojure'},
     'cljc': {'text', 'clojure'},
     'cljs': {'text', 'clojure', 'clojurescript'},


### PR DESCRIPTION
CJS is (was?) used for CommonJS modules in Node. It's not recommended now (https://github.com/nodejs/modules/issues/293) but Node docs mention it (https://nodejs.org/docs/latest/api/modules.html#file-modules), so presumably some code out there uses it. Also Standard JS' pre-commit hook definition applies to such files with `files` rather than `type` (due to lack of identify support): https://github.com/standard/standard/blob/master/.pre-commit-hooks.yaml .