### PR TITLE
add poetry.lock as toml

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -312,6 +312,7 @@ NAMES = {
     'Pipfile': EXTENSIONS['toml'],
     'Pipfile.lock': EXTENSIONS['json'],
     'PKGBUILD': {'text', 'bash', 'pkgbuild', 'alpm'},
+    'poetry.lock': EXTENSIONS['toml'],
     'pylintrc': EXTENSIONS['ini'] | {'pylintrc'},
     'README': EXTENSIONS['txt'],
     'Rakefile': EXTENSIONS['rb'],


### PR DESCRIPTION
I noticed that the lock files from poetry and yarn aren't in here yet. Poetry uses toml. Yarn is another story. Yarn v1 files aren't valid yaml files while Yarn v2 lock files are. I think it's better to go just with a text file here.