### PR TITLE
Add json5 to extensions

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -99,6 +99,7 @@ EXTENSIONS = {
     'js': {'text', 'javascript'},
     'json': {'text', 'json'},
     'jsonnet': {'text', 'jsonnet'},
+    'json5': {'text', 'json5'},
     'jsx': {'text', 'jsx'},
     'key': {'text', 'pem'},
     'kml': {'text', 'kml', 'xml'},


### PR DESCRIPTION
I came across this format recently. It's supported by Renovate as one of its possible configs.

The [official implementation](https://github.com/json5/json5) has gone a little quiet (no activity for a year), but I'm not sure that means there's a problem. Even if it did, the format and libraries for it are out there and being used.

There's no new test for this, since it's just a data change.