### PR TITLE
support identifying qml files as qml language

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -163,6 +163,7 @@ EXTENSIONS = {
     'pyx': {'text', 'cython'},
     'pyz': {'binary', 'pyz'},
     'pyzw': {'binary', 'pyz'},
+    'qml': {'text', 'qml'},
     'r': {'text', 'r'},
     'rake': {'text', 'ruby'},
     'rb': {'text', 'ruby'},


### PR DESCRIPTION
The Qt project provides a language called qml that is provided in .qml files. This language is common enough that it should be identifiable via tags in order to allow pre-commit and other projects to write hooks for those files.