### PR TITLE
(Slightly) expand executable check to include os.stat

### DIFF
--- a/identify/identify.py
+++ b/identify/identify.py
@@ -53,7 +53,12 @@ def tags_from_path(path: str) -> set[str]:
 
     tags = {FILE}
 
-    executable = os.access(path, os.X_OK)
+    # Some systems' access(2) don't correctly surface whether a file is
+    # executable, so we fall back to another check to be sure.
+    executable = (
+        os.access(path, os.X_OK) or
+        bool(os.stat(path).st_mode & stat.S_IXUSR)
+    )
     if executable:
         tags.add(EXECUTABLE)
     else:


### PR DESCRIPTION
Use of virtualized platforms is increasing in popularity. This includes using them to
create consistent environments for local development, despite underlying platforms
potentially varying widely. Even within a single organization of non-trivial size, it's
not unusual to have developers running several different versions of a single OS on
several different hardware revs from the same manufacturer. Containerization is a
popular way to attempt to eliminate environmental differences to achieve consistency.

Some virtualization layers confuse permissions checks inside virtualized environments
when those environments have access to host filesystems. docker/for-mac#5509 is a prime
example.

This expands the ways in which file executability is detected slightly. The prior
os.access check remains. If that should fail, this change includes an os.stat fallback.
Together, these should get closer to detecting whether the file is truly executable on
systems where such confusion is present.

Fixes 289.