### PR TITLE
Gemfile gets also associated with 'ruby.gemfile'

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -298,7 +298,7 @@ NAMES = {
     'CONTRIBUTING': EXTENSIONS['txt'],
     'COPYING': EXTENSIONS['txt'],
     'Dockerfile': {'text', 'dockerfile'},
-    'Gemfile': EXTENSIONS['rb'],
+    'Gemfile': {'ruby.gemfile'} | EXTENSIONS['rb'],
     'Gemfile.lock': {'text'},
     'GNUmakefile': EXTENSIONS['mk'],
     'go.mod': {'text', 'go-mod'},

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -160,7 +160,7 @@ def test_tags_from_path_plist_text(tmpdir):
         ('Pipfile.lock', {'text', 'json'}),
         ('mod/test.py', {'text', 'python'}),
         ('mod/Dockerfile', {'text', 'dockerfile'}),
-        ('Gemfile', {'text', 'ruby'}),
+        ('Gemfile', {'text', 'ruby', 'ruby.gemfile'}),
         ('Gemfile.lock', {'text'}),
         ('Jenkinsfile', {'text', 'groovy', 'jenkins'}),
         ('build.jenkins', {'text', 'groovy', 'jenkins'}),


### PR DESCRIPTION
Useful for detection of grammars (for babi).