### PR TITLE
Add fish shell interpreter

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -51,7 +51,7 @@ EXTENSIONS = {
     'exe': {'binary'},
     'eyaml': {'text', 'yaml'},
     'feature': {'text', 'gherkin'},
-    'fish': {'text', 'fish'},
+    'fish': {'text', 'shell', 'fish'},
     'gd': {'text', 'gdscript'},
     'gemspec': {'text', 'ruby'},
     'geojson': {'text', 'geojson', 'json'},

--- a/identify/interpreters.py
+++ b/identify/interpreters.py
@@ -8,6 +8,7 @@ INTERPRETERS = {
     'csh': {'shell', 'csh'},
     'dash': {'shell', 'dash'},
     'expect': {'expect'},
+    'fish': {'fish'},
     'ksh': {'shell', 'ksh'},
     'node': {'javascript'},
     'nodejs': {'javascript'},

--- a/identify/interpreters.py
+++ b/identify/interpreters.py
@@ -8,7 +8,7 @@ INTERPRETERS = {
     'csh': {'shell', 'csh'},
     'dash': {'shell', 'dash'},
     'expect': {'expect'},
-    'fish': {'fish'},
+    'fish': {'shell', 'fish'},
     'ksh': {'shell', 'ksh'},
     'node': {'javascript'},
     'nodejs': {'javascript'},


### PR DESCRIPTION
This adds [fish](https://fishshell.com) to the interpreters.

In a separate commit I also marked the `fish` entries as `shell` in case omitting it was an oversight. If that was a deliberate decision we can drop the commit.

Let me know if you have any concerns or need anything else from me to move this forward!