### PR TITLE
V (a.k.a. vlang) interpreter and extensions

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -211,7 +211,7 @@ EXTENSIONS = {
     'txsprofile': {'text', 'ini', 'txsprofile'},
     'txt': {'text', 'plain-text'},
     'urdf': {'text', 'xml', 'urdf'},
-    'v': {'text', 'verilog'},
+    'v': {'text', 'verilog', 'v', 'vlang'},
     'vb': {'text', 'vb'},
     'vbproj': {'text', 'xml', 'vbproj'},
     'vcxproj': {'text', 'xml', 'vcxproj'},

--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -220,6 +220,7 @@ EXTENSIONS = {
     'vhd': {'text', 'vhdl'},
     'vim': {'text', 'vim'},
     'vtl': {'text', 'vtl'},
+    'vsh': {'text', 'v', 'vlang'},
     'vue': {'text', 'vue'},
     'war': {'binary', 'zip', 'jar'},
     'wav': {'binary', 'audio', 'wav'},

--- a/identify/interpreters.py
+++ b/identify/interpreters.py
@@ -18,5 +18,6 @@ INTERPRETERS = {
     'ruby': {'ruby'},
     'sh': {'shell', 'sh'},
     'tcsh': {'shell', 'tcsh'},
+    'v': {'v', 'vlang'},
     'zsh': {'shell', 'zsh'},
 }


### PR DESCRIPTION
This adds the `v` file type, as well as the alias `vlang`, to the `.v` extension for the [V Programming Language](https://vlang.io).

A second commit also adds the `.vsh` extension and the `v` interpreter for [V scripts](https://github.com/vlang/v/blob/master/doc/docs.md#cross-platform-shell-scripts-in-v).