### PR TITLE
Add py.typed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,10 @@ console_scripts =
 license =
     ukkonen
 
+[options.package_data]
+identify =
+    py.typed
+
 [bdist_wheel]
 universal = True
 


### PR DESCRIPTION
This library already has type hints
which are checked by running by mypy in CI.

Per https://peps.python.org/pep-0561/,
add a `py.typed` file and include it in the distribution
to mark `identify` as providing type hints
so that consumers of `identify`
can also type check against its type annotations.

resolves https://github.com/pre-commit/identify/issues/295.