### PR TITLE
Add MuseScore file extensions

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -127,6 +127,8 @@ EXTENSIONS = {
     'mli': {'text', 'ocaml'},
     'mm': {'text', 'c++', 'objective-c++'},
     'modulemap': {'text', 'modulemap'},
+    'mscx': {'text', 'xml', 'musescore'},
+    'mscz': {'binary', 'zip', 'musescore'},
     'myst': {'text', 'myst'},
     'ngdoc': {'text', 'ngdoc'},
     'nim': {'text', 'nim'},


### PR DESCRIPTION
Adds support for the `.mscx` and `.mscz` [MuseScore score files](https://musescore.org/en/handbook/3/file-formats#mscz).

These files have nothing to do with programming, other than that `.mscx` files are text files that can efficiently be versioned controlled in git.

I completely understand if these extensions feel unnecessary to include.