### PR TITLE
Add FITS files to extension list

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -52,6 +52,7 @@ EXTENSIONS = {
     'eyaml': {'text', 'yaml'},
     'feature': {'text', 'gherkin'},
     'fish': {'text', 'fish'},
+    'fits': {'binary', 'fits'},
     'gd': {'text', 'gdscript'},
     'gemspec': {'text', 'ruby'},
     'geojson': {'text', 'geojson', 'json'},


### PR DESCRIPTION
This PR adds FITS (https://fits.gsfc.nasa.gov/) files to the extension list.