### PR TITLE
Added env/dotenv file extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -45,6 +45,7 @@ EXTENSIONS = {
     'ear': {'binary', 'zip', 'jar'},
     'edn': {'text', 'clojure', 'edn'},
     'ejs': {'text', 'ejs'},
+    'env': {'text', 'dotenv'},
     'eot': {'binary', 'eot'},
     'eps': {'binary', 'eps'},
     'erb': {'text', 'erb'},


### PR DESCRIPTION
Adding env file extension means, env file validators can run on pre-commit. While it's a bad practice to send .env files to git repo, examples or encrypted templates are very useful.