### PR TITLE
Identify `.importlinter` as an INI-file

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -280,6 +280,7 @@ NAMES = {
     '.gitlint': EXTENSIONS['ini'] | {'gitlint'},
     '.gitmodules': {'text', 'gitmodules'},
     '.hgrc': EXTENSIONS['ini'] | {'hgrc'},
+    '.importlinter': EXTENSIONS['ini'] | {'import-linter'},
     '.isort.cfg': EXTENSIONS['ini'] | {'isort'},
     '.jshintrc': EXTENSIONS['json'] | {'jshintrc'},
     '.mailmap': {'text', 'mailmap'},


### PR DESCRIPTION
_(documented at https://import-linter.readthedocs.io/en/stable/usage.html#configuration-file-location)_