### PR TITLE
Add julie file extension - 'jl'

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -96,6 +96,7 @@ EXTENSIONS = {
     'jenkinsfile': {'text', 'groovy', 'jenkins'},
     'jinja': {'text', 'jinja'},
     'jinja2': {'text', 'jinja'},
+    'jl': {'text', 'julia'},
     'jpeg': {'binary', 'image', 'jpeg'},
     'jpg': {'binary', 'image', 'jpeg'},
     'js': {'text', 'javascript'},


### PR DESCRIPTION
See [Julia getting started instructions](https://docs.julialang.org/en/v1/manual/getting-started/) and/or [their github repo](https://github.com/JuliaLang/julia/tree/master/base) for evidence that `.jl` is the standard file extension for Julia.