### PR TITLE
Add Cylc configs file extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -38,6 +38,7 @@ EXTENSIONS = {
     'cu': {'text', 'cuda'},
     'cuh': {'text', 'cuda'},
     'cxx': {'text', 'c++'},
+    'cylc': {'text', 'cylc'},
     'dart': {'text', 'dart'},
     'def': {'text', 'def'},
     'dll': {'binary'},


### PR DESCRIPTION
Cylc is a workflow tool and they have recently moved to use
the `.cylc` file extension as their standard to ensure it is unique.

See documentation for this file format in [the Cylc documentation](https://cylc.github.io/cylc-doc/latest/html/tutorial/scheduling/graphing.html).