### PR TITLE
Add .resx to extensions.py

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -177,6 +177,7 @@ EXTENSIONS = {
     'r': {'text', 'r'},
     'rake': {'text', 'ruby'},
     'rb': {'text', 'ruby'},
+    'resx': {'text', 'resx', 'xml'},
     'rng': {'text', 'xml', 'relax-ng'},
     'rs': {'text', 'rust'},
     'rst': {'text', 'rst'},


### PR DESCRIPTION
.NET uses *.resx* files to container XML resource descriptors for various resources (e.g. localisation strings, and images) and the IDE manages autogeneration of the XML to describe the contents.
Since it's usually autogenerated, it would be useful to be able to easily target these for exclusion with pre-commit.

I don't know what you consider a canonical source regarding file formats, seeing as anyone can use any format for whatever they choose, but this extension's definition is [generally](https://learn.microsoft.com/en-us/dotnet/core/extensions/work-with-resx-files-programmatically) [well](https://en.wikipedia.org/wiki/List_of_file_formats#Source_code_for_computer_programs) [documented](https://fileinfo.com/extension/resx) [online](https://www.ibm.com/docs/en/cognos-analytics/11.1.0?topic=components-resource-files).

Could be worth adding a [contributing.md](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors) to your project so it's easy for people to see what you expect when sending a PR too :)