### PR TITLE
Add .cue to extensions.py

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -36,6 +36,7 @@ EXTENSIONS = {
     'css': {'text', 'css'},
     'csv': {'text', 'csv'},
     'cu': {'text', 'cuda'},
+    'cue': {'text', 'cue'},
     'cuh': {'text', 'cuda'},
     'cxx': {'text', 'c++'},
     'cylc': {'text', 'cylc'},


### PR DESCRIPTION
This PR adds .cue to extensions.py. 

This extension is used by the cue-lang project: https://github.com/cue-lang/cue, which is a data language.

