### PR TITLE
Adds .make to extensions

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -127,6 +127,7 @@ EXTENSIONS = {
     'lr': {'text', 'lektor'},
     'lua': {'text', 'lua'},
     'm': {'text', 'objective-c'},
+    'make': {'text', 'makefile'},
     'manifest': {'text', 'manifest'},
     'map': {'text', 'map'},
     'markdown': {'text', 'markdown'},


### PR DESCRIPTION
This would enable switching out files for types in the [checkmake hook][1].

[1]: https://github.com/mrtazz/checkmake/commit/4e37f3a6ea00208b3f5bd04eaa0f075068237f18