### PR TITLE
Add support for osascript.

### DIFF
--- a/identify/identify.py
+++ b/identify/identify.py
@@ -103,7 +103,8 @@ def tags_from_filename(path: str) -> set[str]:
 
     return ret
 
-def tags_from_shebang(shebang: tuple[str,...]) -> set[str]:
+
+def tags_from_shebang(shebang: tuple[str, ...]) -> set[str]:
     if len(shebang) > 0:
         interpreter = shebang[0]
         _, _, interpreter = interpreter.rpartition('/')

--- a/identify/interpreters.py
+++ b/identify/interpreters.py
@@ -11,6 +11,7 @@ INTERPRETERS = {
     'ksh': {'shell', 'ksh'},
     'node': {'javascript'},
     'nodejs': {'javascript'},
+    'osascript': {'applescript'},
     'perl': {'perl'},
     'python': {'python'},
     'python2': {'python', 'python2'},

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -189,6 +189,7 @@ def test_tags_from_path_plist_text(tmpdir):
 def test_tags_from_filename(filename, expected):
     assert identify.tags_from_filename(filename) == expected
 
+
 @pytest.mark.parametrize(
     ('shebang', 'expected'),
     (
@@ -200,6 +201,7 @@ def test_tags_from_filename(filename, expected):
 )
 def test_tags_from_shebang(shebang, expected):
     assert identify.tags_from_shebang(shebang) == expected
+
 
 @pytest.mark.parametrize(
     ('interpreter', 'expected'),

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -189,6 +189,17 @@ def test_tags_from_path_plist_text(tmpdir):
 def test_tags_from_filename(filename, expected):
     assert identify.tags_from_filename(filename) == expected
 
+@pytest.mark.parametrize(
+    ('shebang', 'expected'),
+    (
+        (('/usr/bin/python',), {'python'}),
+        (('/usr/bin/osascript',), {'applescript'}),
+        (('/usr/bin/osascript', '-l', 'JavaScript'), {'javascript'}),
+        (('/usr/bin/osascript', '-l', 'AppleScript'), {'applescript'}),
+    ),
+)
+def test_tags_from_shebang(shebang, expected):
+    assert identify.tags_from_shebang(shebang) == expected
 
 @pytest.mark.parametrize(
     ('interpreter', 'expected'),


### PR DESCRIPTION
Unlike most other interpreters, osascript supports multiple languages via the -l flag. Identify osascript as either applescript or javascript depending on that flag.