### PR TITLE
Add .pug to extensions.py

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -168,6 +168,7 @@ EXTENSIONS = {
     'properties': {'text', 'java-properties'},
     'proto': {'text', 'proto'},
     'ps1': {'text', 'powershell'},
+    'pug': {'text', 'pug'},
     'puml': {'text', 'plantuml'},
     'purs': {'text', 'purescript'},
     'pxd': {'text', 'cython'},


### PR DESCRIPTION
.pug is an extension used by the template engine [Pug](https://github.com/pugjs/pug).