### PR TITLE
Add file type support for CAN database files (.dbc)

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -41,6 +41,7 @@ EXTENSIONS = {
     'cxx': {'text', 'c++'},
     'cylc': {'text', 'cylc'},
     'dart': {'text', 'dart'},
+    'dbc': {'text', 'dbc'},
     'def': {'text', 'def'},
     'dll': {'binary'},
     'dtd': {'text', 'dtd'},


### PR DESCRIPTION
This adds `.dbc` files also known as CAN database files to the the supported file extensions. See https://docs.fileformat.com/database/dbc/ as a reference.