### PR TITLE
Add *.textproto support

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -223,6 +223,7 @@ EXTENSIONS = {
     'tac': {'text', 'twisted', 'python'},
     'tar': {'binary', 'tar'},
     'tex': {'text', 'tex'},
+    'textproto': {'text', 'textproto'},
     'tf': {'text', 'terraform'},
     'tfvars': {'text', 'terraform'},
     'tgz': {'binary', 'gzip'},


### PR DESCRIPTION
This will allow e.g. https://github.com/pre-commit/mirrors-clang-format to format https://protobuf.dev/reference/protobuf/textformat-spec/ files together with https://github.com/pre-commit/mirrors-clang-format/pull/22.