### PR TITLE
Adds support for with-contenv of s6-overlay

### DIFF
--- a/identify/identify.py
+++ b/identify/identify.py
@@ -191,7 +191,7 @@ def parse_shebang(bytesio: IO[bytes]) -> tuple[str, ...]:
             return ()
 
     cmd = tuple(_shebang_split(first_line.strip()))
-    if cmd and cmd[0] == '/usr/bin/env':
+    if cmd and (cmd[0] == '/usr/bin/env' or 'with-contenv' in cmd[0]):
         if cmd[1] == '-S':
             cmd = cmd[2:]
         else:

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -255,6 +255,9 @@ def test_file_is_text_does_not_exist(tmpdir):
         (b"#!/path'with/quotes    y", ("/path'with/quotes", 'y')),
         # Don't regress on leading/trailing ws
         (b"#! /path'with/quotes y ", ("/path'with/quotes", 'y')),
+        #
+        (b'#!/usr/bin/with-contenv bash', ('bash',)),
+        (b'#!/command/with-contenv sh', ('sh',)),
         # Test nix-shell specialites with shebang on second line
         (
             b'#! /usr/bin/env nix-shell\n'


### PR DESCRIPTION
[s6-overlay](https://github.com/just-containers/s6-overlay) is a popular container process supervision suite.  It provides two shebang values for running a given command with the container's environment: `#!/usr/bin/with-contenv` or `#!/command/with-contenv`.  Both are essentially the same thing as `#!/usr/bin/env` but for containers.

This PR adds support for identifying the command run with these shebangs.  As the two styles/types exist, an `in` check instead of exactly equal was used (but could be updated)