### PR TITLE
Add fmf extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -63,6 +63,7 @@ EXTENSIONS = {
     'feature': {'text', 'gherkin'},
     'fish': {'text', 'fish'},
     'fits': {'binary', 'fits'},
+    'fmf': {'text', 'fmf', 'yaml'},
     'gd': {'text', 'gdscript'},
     'gemspec': {'text', 'ruby'},
     'geojson': {'text', 'geojson', 'json'},


### PR DESCRIPTION
[.fmf](https://fmf.readthedocs.io/en/stable/concept.html#files) files are yaml text files used most notably in [tmt](https://github.com/teemtee/tmt).

Could for example be used in [tmt-lint pre-commit hooks](https://github.com/teemtee/tmt/blob/main/.pre-commit-hooks.yaml) or when running yaml linters against .fmf files.

See: https://github.com/teemtee/tmt/discussions/2164