### PR TITLE
Add txtpb extension.

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -247,6 +247,7 @@ EXTENSIONS = {
     'twig': {'text', 'twig'},
     'txsprofile': {'text', 'ini', 'txsprofile'},
     'txt': {'text', 'plain-text'},
+    'txtpb': {'text', 'textproto'},
     'urdf': {'text', 'xml', 'urdf'},
     'v': {'text', 'verilog'},
     'vb': {'text', 'vb'},


### PR DESCRIPTION
Adds the canonical extension for text-serialized protocol buffers. ([source](https://protobuf.dev/reference/protobuf/textformat-spec/#text-format-files))