### PR TITLE
Support identifying copy.bara.sky

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -338,6 +338,7 @@ NAMES = {
     'config.ru': EXTENSIONS['rb'],
     'Containerfile': {'text', 'dockerfile'},
     'CONTRIBUTING': EXTENSIONS['txt'],
+    'copy.bara.sky': EXTENSIONS['bzl'],
     'COPYING': EXTENSIONS['txt'],
     'Dockerfile': {'text', 'dockerfile'},
     'Gemfile': EXTENSIONS['rb'],


### PR DESCRIPTION
Add `copy.bara.sky` which is the default config file of [copybara](https://github.com/google/copybara). It is a starlark file like `.bzl`.

Not adding `.sky` extension as I did not see any other starlark file use `.sky` as extension.