### PR TITLE
Add GGB file extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -74,6 +74,7 @@ EXTENSIONS = {
     'gd': {'text', 'gdscript'},
     'gemspec': {'text', 'ruby'},
     'geojson': {'text', 'geojson', 'json'},
+    'ggb': {'binary', 'zip', 'ggb'},
     'gif': {'binary', 'image', 'gif'},
     'go': {'text', 'go'},
     'gotmpl': {'text', 'gotmpl'},


### PR DESCRIPTION
`.ggb` file extensions are used for [GeoGebra](https://www.geogebra.org/?lang=en) drawings. 

Web research did not result in any ambiguity, but pointed straight to this usecase (https://fileinfo.com/extension/ggb).

I also ran a `file my_file.ggb` which resulted in `Zip archive data, at least v2.0 to extract`