### PR TITLE
add .k (kcl file type) to extensions.py

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -125,6 +125,7 @@ EXTENSIONS = {
     'jsonnet': {'text', 'jsonnet'},
     'json5': {'text', 'json5'},
     'jsx': {'text', 'jsx'},
+    'k': {'text', 'kcl'},
     'key': {'text', 'pem'},
     'kml': {'text', 'kml', 'xml'},
     'kt': {'text', 'kotlin'},


### PR DESCRIPTION
This PR add `.k` file type into extensions.py
This extension is used by files for [kcl](https://kcl-lang.io/).