### PR TITLE
Add xacro extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -269,6 +269,7 @@ EXTENSIONS = {
     'woff2': {'binary', 'woff2'},
     'wsgi': {'text', 'wsgi', 'python'},
     'xhtml': {'text', 'xml', 'html', 'xhtml'},
+    'xacro': {'text', 'xml', 'urdf', 'xacro'},
     'xml': {'text', 'xml'},
     'xq': {'text', 'xquery'},
     'xql': {'text', 'xquery'},


### PR DESCRIPTION
I was honestly surprised that `urdf` was [already supported](https://github.com/pre-commit/identify/pull/210), but I'm taking it further and adding [`xacro`](https://github.com/ros/xacro)

