### PR TITLE
feat: identify `Vagrantfile` as Ruby

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -371,6 +371,7 @@ NAMES = {
     'setup.cfg': EXTENSIONS['ini'],
     'sys.config': EXTENSIONS['erl'],
     'sys.config.src': EXTENSIONS['erl'],
+    'Vagrantfile': EXTENSIONS['rb'],
     'WORKSPACE': EXTENSIONS['bzl'],
     'wscript': EXTENSIONS['py'],
 }

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -170,6 +170,7 @@ def test_tags_from_path_plist_text(tmpdir):
         ('build.jenkinsfile', {'text', 'groovy', 'jenkins'}),
         ('meson.build', {'text', 'meson'}),
         ('meson_options.txt', {'text', 'plain-text', 'meson'}),
+        ('Vagrantfile', {'text', 'ruby'}),
 
         # does not set binary / text
         ('f.plist', {'plist'}),


### PR DESCRIPTION
* "The syntax of Vagrantfiles is Ruby" ref. https://developer.hashicorp.com/vagrant/docs/vagrantfile
