### PR TITLE
feat: identify `.salt-lint` as YAML

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -328,6 +328,7 @@ NAMES = {
     '.prettierignore': {'text', 'gitignore', 'prettierignore'},
     '.pypirc': EXTENSIONS['ini'] | {'pypirc'},
     '.rstcheck.cfg': EXTENSIONS['ini'],
+    '.salt-lint': EXTENSIONS['yaml'] | {'salt-lint'},
     '.yamllint': EXTENSIONS['yaml'] | {'yamllint'},
     '.zlogin': EXTENSIONS['zsh'],
     '.zlogout': EXTENSIONS['zsh'],

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -151,6 +151,7 @@ def test_tags_from_path_plist_text(tmpdir):
 @pytest.mark.parametrize(
     ('filename', 'expected'),
     (
+        ('.salt-lint', {'text', 'salt-lint', 'yaml'}),
         ('test.py', {'text', 'python'}),
         ('test.mk', {'text', 'makefile'}),
         ('Makefile', {'text', 'makefile'}),


### PR DESCRIPTION
* "Salt-lint supports local configuration via a .salt-lint configuration file" ref.
  https://github.com/warpnet/salt-lint/blob/main/docs/index.md#configuration-file
