### PR TITLE
Add `empty` tag for zero-length files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ If you have an actual file on disk, you can get the most information possible
 {'file', 'text', 'python', 'non-executable'}
 >>> identify.tags_from_path('/path/to/file-with-shebang')
 {'file', 'text', 'shell', 'bash', 'executable'}
+>>> identify.tags_from_path('/path/to/__init__.py')
+{'file', 'text', 'python', 'empty', 'non-executable'}
 >>> identify.tags_from_path('/bin/bash')
 {'file', 'binary', 'executable'}
 >>> identify.tags_from_path('/path/to/directory')
@@ -39,6 +41,7 @@ When using a file on disk, the checks performed are:
 
 * File type (file, symlink, directory, socket)
 * Mode (is it executable?)
+* Size (is it empty, i.e. zero-length?)
 * File name (mostly based on extension)
 * If executable, the shebang is read and the interpreter interpreted
 
@@ -124,7 +127,7 @@ licenses are sourced from [choosealicense.com].
 A call to `tags_from_path` does this:
 
 1. What is the type: file, symlink, directory? If it's not file, stop here.
-2. Is it executable? Add the appropriate tag.
+2. Is it executable? Zero-length? Add the appropriate tags.
 3. Do we recognize the file extension? If so, add the appropriate tags, stop
    here. These tags would include binary/text.
 4. Peek at the first X bytes of the file. Use these to determine whether it is

--- a/identify/identify.py
+++ b/identify/identify.py
@@ -25,11 +25,12 @@ EXECUTABLE = 'executable'
 NON_EXECUTABLE = 'non-executable'
 TEXT = 'text'
 BINARY = 'binary'
+EMPTY = 'empty'
 
 TYPE_TAGS = frozenset((DIRECTORY, FILE, SYMLINK, SOCKET))
 MODE_TAGS = frozenset((EXECUTABLE, NON_EXECUTABLE))
 ENCODING_TAGS = frozenset((BINARY, TEXT))
-_ALL_TAGS = {*TYPE_TAGS, *MODE_TAGS, *ENCODING_TAGS}
+_ALL_TAGS = {*TYPE_TAGS, *MODE_TAGS, *ENCODING_TAGS, EMPTY}
 _ALL_TAGS.update(*extensions.EXTENSIONS.values())
 _ALL_TAGS.update(*extensions.EXTENSIONS_NEED_BINARY_CHECK.values())
 _ALL_TAGS.update(*extensions.NAMES.values())
@@ -52,6 +53,9 @@ def tags_from_path(path: str) -> set[str]:
         return {SOCKET}
 
     tags = {FILE}
+
+    if sr.st_size == 0:
+        tags.add(EMPTY)
 
     executable = os.access(path, os.X_OK)
     if executable:

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -20,6 +20,7 @@ def test_all_tags_includes_basic_ones():
     assert 'executable' in identify.ALL_TAGS
     assert 'text' in identify.ALL_TAGS
     assert 'socket' in identify.ALL_TAGS
+    assert 'empty' in identify.ALL_TAGS
 
 
 @pytest.mark.parametrize(
@@ -80,7 +81,7 @@ def test_tags_from_path_broken_symlink(tmpdir):
 def test_tags_from_path_simple_file(tmpdir):
     x = tmpdir.join('test.py').ensure()
     assert identify.tags_from_path(x.strpath) == {
-        'file', 'text', 'non-executable', 'python',
+        'file', 'text', 'non-executable', 'python', 'empty',
     }
 
 


### PR DESCRIPTION
I have a local pre-commit hook using `pygrep --negate` to verify that Python files include a particular `__future__` import, and would like to exclude empty `__init__.py` files from the check.

For reference, `file` also has a special case for zero-length files:

```console
$ file __init__.py 
__init__.py: empty
```