### PR TITLE
feat: identify `.avsc` as Avro schema

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -7,6 +7,7 @@ EXTENSIONS = {
     'apinotes': {'text', 'apinotes'},
     'asar': {'binary', 'asar'},
     'avif': {'binary', 'image', 'avif'},
+    'avsc': {'text', 'avro-schema'},
     'bash': {'text', 'shell', 'bash'},
     'bat': {'text', 'batch'},
     'bats': {'text', 'shell', 'bash', 'bats'},


### PR DESCRIPTION
> Schema files use the extension ".avsc", while encoded files (of any sort) use the extension ".avro"

http://fileformats.archiveteam.org/wiki/Avro