### PR TITLE
Add `pyt` extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -197,6 +197,7 @@ EXTENSIONS = {
     'py': {'text', 'python'},
     'pyi': {'text', 'pyi'},
     'pyproj': {'text', 'xml', 'pyproj'},
+    'pyt': {'text', 'python'},
     'pyx': {'text', 'cython'},
     'pyz': {'binary', 'pyz'},
     'pyzw': {'binary', 'pyz'},


### PR DESCRIPTION
`pyt` is the extension for the [Esri Python Toolbox](https://pro.arcgis.com/en/pro-app/latest/arcpy/geoprocessing_and_python/a-quick-tour-of-python-toolboxes.htm) file format, written in plain text Python.