### PR TITLE
Detect ScalaFmt config as a scala file

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -331,6 +331,7 @@ NAMES = {
     '.pypirc': EXTENSIONS['ini'] | {'pypirc'},
     '.rstcheck.cfg': EXTENSIONS['ini'],
     '.salt-lint': EXTENSIONS['yaml'] | {'salt-lint'},
+    '.scalafmt.conf': {'text', 'scalafmt'},
     '.yamllint': EXTENSIONS['yaml'] | {'yamllint'},
     '.zlogin': EXTENSIONS['zsh'],
     '.zlogout': EXTENSIONS['zsh'],

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -152,6 +152,7 @@ def test_tags_from_path_plist_text(tmpdir):
     ('filename', 'expected'),
     (
         ('.salt-lint', {'text', 'salt-lint', 'yaml'}),
+        ('.scalafmt.conf', {'text', 'scalafmt'}),
         ('test.py', {'text', 'python'}),
         ('test.mk', {'text', 'makefile'}),
         ('Makefile', {'text', 'makefile'}),


### PR DESCRIPTION
Add ScalaFmt config so that pre-commit hooks will check changes to the config file and get latest

Currently when I run precommit on a scala repository using a hook that has:
`types: [scala]`
set in .pre-commit-hooks.yaml and I have local edits to my .scalafmt.conf file, precommit doesn't run the hook script as it doesn't find any scala files that have changed.

Identifying .scalafmt.conf as a scala file will fix this