### PR TITLE
feat: Indentify `metal` as Metal Shading Language

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -151,6 +151,7 @@ EXTENSIONS = {
     'md': {'text', 'markdown'},
     'mdx': {'text', 'mdx'},
     'meson': {'text', 'meson'},
+    'metal': {'text', 'metal'},
     'mib': {'text', 'mib'},
     'mjs': {'text', 'javascript'},
     'mk': {'text', 'makefile'},


### PR DESCRIPTION
Metal Programming guide: Metal Tools

> ## File Extension for Metal Shading Language Source Files
>
> For Metal shading language source code file names, you must use the
> .metal file name extension to ensure that the development tools
> (Xcode and the GPU frame debugger) recognize the source files when
> debugging or profiling.