### PR TITLE
Identify Cargo.toml and Cargo.lock as cargo and cargo-lock

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -341,6 +341,8 @@ NAMES = {
     '.zshenv': EXTENSIONS['zsh'],
     'AUTHORS': EXTENSIONS['txt'],
     'BUILD': EXTENSIONS['bzl'],
+    'Cargo.toml': EXTENSIONS['toml'] | {'cargo'},
+    'Cargo.lock': EXTENSIONS['toml'] | {'cargo-lock'},
     'CMakeLists.txt': EXTENSIONS['cmake'],
     'CHANGELOG': EXTENSIONS['txt'],
     'config.ru': EXTENSIONS['rb'],


### PR DESCRIPTION
Introduce dedicated types for Cargo.toml and Cargo.lock files. These are similar to go.mod and go.sum files.