### PR TITLE
Add ejson extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -56,6 +56,7 @@ EXTENSIONS = {
     'ear': {'binary', 'zip', 'jar'},
     'edn': {'text', 'clojure', 'edn'},
     'ejs': {'text', 'ejs'},
+    'ejson': {'text', 'json', 'ejson'},
     'env': {'text', 'dotenv'},
     'eot': {'binary', 'eot'},
     'eps': {'binary', 'eps'},


### PR DESCRIPTION
`ejson` is a pretty popular "encrypted json" format and open source tool built by Shopify. `ejson` files are just JSON files where terminal string nodes are encrypted.

[More info](https://github.com/Shopify/ejson)