### PR TITLE
Identify rust-toolchain files as rust-toolchain

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -375,6 +375,8 @@ NAMES = {
     'README': EXTENSIONS['txt'],
     'Rakefile': EXTENSIONS['rb'],
     'rebar.config': EXTENSIONS['erl'],
+    'rust-toolchain': EXTENSIONS['toml'] | {'rust-toolchain'},
+    'rust-toolchain.toml': EXTENSIONS['toml'] | {'rust-toolchain'},
     'setup.cfg': EXTENSIONS['ini'],
     'sys.config': EXTENSIONS['erl'],
     'sys.config.src': EXTENSIONS['erl'],


### PR DESCRIPTION
Introduce dedicated types for rust-toolchain and rust-toolchain.toml files. Cargo linting rules can change with the rust version, so it's helpful to match against the rust-toolchain files as a trigger for Rust linting hooks.