### PR TITLE
Add support for Typst

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -252,6 +252,7 @@ EXTENSIONS = {
     'txsprofile': {'text', 'ini', 'txsprofile'},
     'txt': {'text', 'plain-text'},
     'txtpb': {'text', 'textproto'},
+    'typ': {'text', 'typst'},
     'urdf': {'text', 'xml', 'urdf'},
     'v': {'text', 'verilog'},
     'vb': {'text', 'vb'},


### PR DESCRIPTION
This PR adds support for [Typst](https://typst.app/docs/), a markup-based typesetting system. Typst files have the extension `.typ`.

