### PR TITLE
Support fmf

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -74,6 +74,7 @@ EXTENSIONS = {
     'feature': {'text', 'gherkin'},
     'fish': {'text', 'fish'},
     'fits': {'binary', 'fits'},
+    'fmf': {'text', 'yaml'},
     'gd': {'text', 'gdscript'},
     'gemspec': {'text', 'ruby'},
     'geojson': {'text', 'geojson', 'json'},


### PR DESCRIPTION
fmf ("Flexible Metadata Format") is a YAML-based file format, mainly used to
describe tests with the TMT framework. TMT is used by RHEL-based distributions
for integration testing of packages.

See also https://fmf.readthedocs.io/en/stable/concept.html#choices.
