### PR TITLE
feat: identify bz3 files as bzip3 archives

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -20,6 +20,7 @@ EXTENSIONS = {
     'bib': {'text', 'bib'},
     'bmp': {'binary', 'image', 'bitmap'},
     'bz2': {'binary', 'bzip2'},
+    'bz3': {'binary', 'bzip3'},
     'bzl': {'text', 'bazel'},
     'c': {'text', 'c'},
     'c++': {'text', 'c++'},


### PR DESCRIPTION
Add identification of archives in the [bzip3 format](https://github.com/kspalaiologos/bzip3).