### PR TITLE
Add Tiltfile

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -393,6 +393,7 @@ NAMES = {
     'setup.cfg': EXTENSIONS['ini'],
     'sys.config': EXTENSIONS['erl'],
     'sys.config.src': EXTENSIONS['erl'],
+    'Tiltfile': {'text', 'tiltfile'},
     'Vagrantfile': EXTENSIONS['rb'],
     'WORKSPACE': EXTENSIONS['bzl'],
     'wscript': EXTENSIONS['py'],

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -172,6 +172,9 @@ def test_tags_from_path_plist_text(tmpdir):
         ('meson.build', {'text', 'meson'}),
         ('meson_options.txt', {'text', 'plain-text', 'meson'}),
         ('Vagrantfile', {'text', 'ruby'}),
+        ('Tiltfile', {'text', 'tiltfile'}),
+        ('Tiltfile.abc', {'text', 'tiltfile'}),
+        ('test.Tiltfile', {'text', 'tiltfile'}),
 
         # does not set binary / text
         ('f.plist', {'plist'}),


### PR DESCRIPTION
Add Tiltfile ~~+ Starlark~~ support. Tiltfiles are written in Starlark, which is a language intended for use as a configuration language. It was originally designed for the [Bazel](https://bazel.build/) build system. Starlark is a dialect of **Python**.

~~background: Lots of Python targeting pre-commit hooks (like ruff) can also be applied to Starlark files. This PR enables to apply those hooks via specifying `types_or: [starlark]` or  `types_or: [tiltfile]` or `types_or: [bazel]` depending on what is needed. Not every Python pre-commit hook applies to every Starlark file, as there are different variants with some [language features](https://pkg.go.dev/go.starlark.net/resolve?utm_source=godoc#pkg-variables) enabled or disabled.~~

refs:
* https://docs.tilt.dev/api
* https://github.com/bazelbuild/starlark