### PR TITLE
feat: identify .psm1 and .psd1 files as powershell

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -201,6 +201,8 @@ EXTENSIONS = {
     'properties': {'text', 'java-properties'},
     'proto': {'text', 'proto'},
     'ps1': {'text', 'powershell'},
+    'psd1': {'text', 'powershell'},
+    'psm1': {'text', 'powershell'},
     'pug': {'text', 'pug'},
     'puml': {'text', 'plantuml'},
     'purs': {'text', 'purescript'},


### PR DESCRIPTION
`.psm1` are PowerShell module files, `.psd1` are PowerShell data files (https://learn.microsoft.com/en-us/powershell/scripting/developer/module/understanding-a-windows-powershell-module?view=powershell-7.4).