### PR TITLE
feat: add `templ` to extensions.py

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -250,6 +250,7 @@ EXTENSIONS = {
     'swiftdeps': {'text', 'swiftdeps'},
     'tac': {'text', 'twisted', 'python'},
     'tar': {'binary', 'tar'},
+    'templ': {'text', 'templ'},
     'tex': {'text', 'tex'},
     'textproto': {'text', 'textproto'},
     'tf': {'text', 'terraform'},


### PR DESCRIPTION
Adds `.templ` as an extension as per https://templ.guide/core-concepts/template-generation