### PR TITLE
Identify XSLT files

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -301,6 +301,7 @@ EXTENSIONS = {
     'xqy': {'text', 'xquery'},
     'xsd': {'text', 'xml', 'xsd'},
     'xsl': {'text', 'xml', 'xsl'},
+    'xslt': {'text', 'xml', 'xsl'},
     'yaml': {'text', 'yaml'},
     'yamlld': {'text', 'yaml', 'yamlld'},
     'yang': {'text', 'yang'},


### PR DESCRIPTION
https://www.w3.org/TR/xslt20/#xslt-mime-definition

> XSLT documents are most often identified with the extensions " .xsl " or " .xslt ".