### PR TITLE
Identify LLVM TableGen files

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -252,6 +252,7 @@ EXTENSIONS = {
     'swiftdeps': {'text', 'swiftdeps'},
     'tac': {'text', 'twisted', 'python'},
     'tar': {'binary', 'tar'},
+    'td': {'text', 'tablegen'},
     'templ': {'text', 'templ'},
     'tex': {'text', 'tex'},
     'textproto': {'text', 'textproto'},


### PR DESCRIPTION
https://llvm.org/docs/TableGen/ProgRef.html#source-files
> The standard file extension for TableGen files is .td.