### PR TITLE
Add names of rust linter and formatter config files

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -374,6 +374,7 @@ NAMES = {
     'BUILD': EXTENSIONS['bzl'],
     'Cargo.toml': EXTENSIONS['toml'] | {'cargo'},
     'Cargo.lock': EXTENSIONS['toml'] | {'cargo-lock'},
+    'deny.toml': EXTENSIONS['toml'] | {'cargo-deny'},
     'clippy.toml': EXTENSIONS['toml'] | {'clippy'},
     'CMakeLists.txt': EXTENSIONS['cmake'],
     'CHANGELOG': EXTENSIONS['txt'],


### PR DESCRIPTION
In Rust there is a default formatter, called `rustfmt`, and a default linter, called `clippy`. This Pull Request adds the names (with and without leading dot) of their config files (see commit message for links to the respective documentations).
Furthermore, the single file name for `cargo-deny`, a linter focused on cargo / Rust dependencies.

(Useful, when running them with `pre-commit` and only want to run, if relevant files have changed, i.e., rust files, `Cargo.toml` or the config file in the repository. Example `pre-commit` config for a Rust project [here](https://codeberg.org/BaumiCoder/ecformat/src/branch/feature/2-linters/.pre-commit-config.yaml))