### PR TITLE
fix: make PKGBUILD files a superset of .bash

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -399,7 +399,7 @@ NAMES = {
     'PATENTS': EXTENSIONS['txt'],
     'Pipfile': EXTENSIONS['toml'],
     'Pipfile.lock': EXTENSIONS['json'],
-    'PKGBUILD': {'text', 'bash', 'pkgbuild', 'alpm'},
+    'PKGBUILD': EXTENSIONS['bash'] | {'pkgbuild', 'alpm'},
     'poetry.lock': EXTENSIONS['toml'],
     'pom.xml': EXTENSIONS['pom'],
     'pylintrc': EXTENSIONS['ini'] | {'pylintrc'},


### PR DESCRIPTION
Arch Linux/ALPM PKGBUILDs are not currently being identified as `shell` files, but they’re really just specialised bash scripts, and thus also `shell` files.

This makes `PKGBUILD` files a superset of the `bash` extension, which both makes it inherit the `shell` type, and also ensures that it will automatically adopt any future changes/additions that might be made to the `bash` extension.