### PR TITLE
Added support for busybox sh

### DIFF
--- a/identify/identify.py
+++ b/identify/identify.py
@@ -195,6 +195,8 @@ def parse_shebang(bytesio: IO[bytes]) -> tuple[str, ...]:
         cmd = cmd[2:]
     elif cmd[:1] == ('/usr/bin/env',):
         cmd = cmd[1:]
+    elif cmd[:1] == ('/bin/busybox',):
+        cmd = cmd[1:]
 
     if cmd == ('nix-shell',):
         return _parse_nix_shebang(bytesio, cmd)

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -261,6 +261,7 @@ def test_file_is_text_does_not_exist(tmpdir):
         (b'#!/usr/bin/env python', ('python',)),
         (b'#! /usr/bin/python', ('/usr/bin/python',)),
         (b'#!/usr/bin/foo  python', ('/usr/bin/foo', 'python')),
+        (b'#!/bin/busybox sh', ('sh',)),
         # despite this being invalid, setuptools will write shebangs like this
         (b'#!"/path/with spaces/x" y', ('/path/with spaces/x', 'y')),
         # this is apparently completely ok to embed quotes


### PR DESCRIPTION
Added support for `busybox sh` to `parse_shebang` so that scripts that start with `#!/bin/busybox sh` are supported