### PR TITLE
Add 'escript' file type and interpreter for Erlang

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -72,6 +72,7 @@ EXTENSIONS = {
     'eps': {'binary', 'eps'},
     'erb': {'text', 'erb'},
     'erl': {'text', 'erlang'},
+    'escript': {'text', 'erlang'},
     'ex': {'text', 'elixir'},
     'exe': {'binary'},
     'exs': {'text', 'elixir'},

--- a/identify/interpreters.py
+++ b/identify/interpreters.py
@@ -8,6 +8,7 @@ INTERPRETERS = {
     'csh': {'shell', 'csh'},
     'dash': {'shell', 'dash'},
     'expect': {'expect'},
+    'escript': {'erlang'},
     'ksh': {'shell', 'ksh'},
     'node': {'javascript'},
     'nodejs': {'javascript'},


### PR DESCRIPTION
Hope I understand it correctly.
File types with `my_script.escript` should be added as Erlang, as well as when the file type is missing it can be matched by the shebang `#!/usr/bin/env escript`  

https://www.erlang.org/doc/apps/erts/escript_cmd

Thank you