### PR TITLE
Add jbuilder extension as ruby text files

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -128,6 +128,7 @@ EXTENSIONS = {
     'jade': {'text', 'jade'},
     'jar': {'binary', 'zip', 'jar'},
     'java': {'text', 'java'},
+    'jbuilder': {'text', 'jbuilder', 'ruby'},
     'jenkins': {'text', 'groovy', 'jenkins'},
     'jenkinsfile': {'text', 'groovy', 'jenkins'},
     'jinja': {'text', 'jinja'},


### PR DESCRIPTION
[jbuilder](https://github.com/rails/jbuilder) is a rails library for rendering json payloads, those files are expected to be written in ruby