### PR TITLE
Add support for xcodebuild file formats

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -299,7 +299,10 @@ EXTENSIONS = {
     'wsgi': {'text', 'wsgi', 'python'},
     'xhtml': {'text', 'xml', 'html', 'xhtml'},
     'xacro': {'text', 'xml', 'urdf', 'xacro'},
-    'xctestplan': {'text', 'json'},
+    'xcconfig': {'text', 'xcconfig', 'xcodebuild'},
+    'xcscheme': {'text', 'xml', 'xcscheme', 'xcodebuild'},
+    'xctestplan': {'text', 'json', 'xctestplan', 'xcodebuild'},
+    'xcworkspacedata': {'text', 'xml', 'xcworkspacedata', 'xcodebuild'},
     'xlf': {'text', 'xml', 'xliff'},
     'xliff': {'text', 'xml', 'xliff'},
     'xml': {'text', 'xml'},
@@ -326,6 +329,8 @@ EXTENSIONS = {
 EXTENSIONS_NEED_BINARY_CHECK = {
     'plist': {'plist'},
     'ppm': {'image', 'ppm'},
+    'xcprivacy': {'plist', 'xcprivacy', 'xcodebuild'},
+    'xcsettings': {'plist', 'xcsettings', 'xcodebuild'},
 }
 
 NAMES = {


### PR DESCRIPTION
This PR adds support for various `xcodebuild` related file formats.

I've modeled this change based on the pre-existing MSBuild formats. For every new extension:
- If it is a non-plist format, it gets the `text` tag. (plists are put in the `EXTENSIONS_NEED_BINARY_CHECK` dictionary without a `text` tag.)
- If the format is implemented as a known format (JSON/XML/plist), it gets the appropriate tag.
- It gets its own tag, same as the extension.
- It gets an `xcodebuild` tag to group all of them, similarly as the `msbuild` tag.

I've applied the same tagging logic to the pre-existing `xctestplan` format. (I.e. I added the `xcodebuild` tag to it.)

Unfortunately, I did not find direct sources from Apple's documentation about the internals of all the formats, but I've verified each of them based on examples and third-party blogposts.