### PR TITLE
Add support for Brewfile

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -373,6 +373,7 @@ NAMES = {
     'AUTHORS': EXTENSIONS['txt'],
     'bblayers.conf': EXTENSIONS['bb'],
     'bitbake.conf': EXTENSIONS['bb'],
+    'Brewfile': EXTENSIONS['rb'],
     'BUILD': EXTENSIONS['bzl'],
     'Cargo.toml': EXTENSIONS['toml'] | {'cargo'},
     'Cargo.lock': EXTENSIONS['toml'] | {'cargo-lock'},


### PR DESCRIPTION
Description of format: https://docs.brew.sh/Brew-Bundle-and-Brewfile

Relevant quote (from the "Advanced Brewfiles" section):
> Brewfiles are evaluated as Ruby so you can use Ruby logic in them.