### PR TITLE
Add support for Fastfile

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -385,6 +385,7 @@ NAMES = {
     'COPYING': EXTENSIONS['txt'],
     'Dockerfile': {'text', 'dockerfile'},
     'direnvrc': EXTENSIONS['bash'],
+    'Fastfile': EXTENSIONS['rb'],
     'Gemfile': EXTENSIONS['rb'],
     'Gemfile.lock': {'text'},
     'GNUmakefile': EXTENSIONS['mk'],


### PR DESCRIPTION
`Fastfile` is a Ruby DSL file with a fixed name, used by fastlane: https://docs.fastlane.tools/advanced/Fastfile
