### PR TITLE
Add support for uv.lock

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -414,6 +414,7 @@ NAMES = {
     'sys.config': EXTENSIONS['erl'],
     'sys.config.src': EXTENSIONS['erl'],
     'Tiltfile': {'text', 'tiltfile'},
+    'uv.lock': EXTENSIONS['toml'],
     'Vagrantfile': EXTENSIONS['rb'],
     'WORKSPACE': EXTENSIONS['bzl'],
     'wscript': EXTENSIONS['py'],


### PR DESCRIPTION
Format documentation: https://docs.astral.sh/uv/guides/projects/#uvlock

Relevant quote:
> uv.lock is a human-readable TOML file but is managed by uv and should not be edited manually.