### PR TITLE
Add support for *.hlsl and *.hlsli

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -103,6 +103,8 @@ EXTENSIONS = {
     'h': {'text', 'header', 'c', 'c++'},
     'hbs': {'text', 'handlebars'},
     'hcl': {'text', 'hcl'},
+    'hlsl': {'text', 'hlsl'},
+    'hlsli': {'text', 'hlsl'},
     'hh': {'text', 'header', 'c++'},
     'hpp': {'text', 'header', 'c++'},
     'hrl': {'text', 'erlang'},


### PR DESCRIPTION
Documentation: https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl

I did not find any direct source in the above docs saying that `.hlsl` is the standard extension, but Google's not giving me anything else, so it seem unambigiouos enough.

I've found this on the Stack Overflow answer on the `.hlsl` / `.hlsli` distinction though, and it matches existing practice I've seen in the wild: https://stackoverflow.com/questions/46809070/what-is-the-difference-between-hlsl-and-hlsli