### PR TITLE
Add support for *.cmd

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -35,6 +35,7 @@ EXTENSIONS = {
     'cljc': {'text', 'clojure'},
     'cljs': {'text', 'clojure', 'clojurescript'},
     'cmake': {'text', 'cmake'},
+    'cmd': {'text', 'batch'},
     'cnf': {'text'},
     'coffee': {'text', 'coffee'},
     'conf': {'text'},


### PR DESCRIPTION
`.cmd` is an alternative extension for Windows batch files (`.bat`), with some minor behavioural differences:
- https://en.wikipedia.org/wiki/Batch_file#Filename_extensions
- https://stackoverflow.com/questions/148968/windows-batch-files-bat-vs-cmd

The only other format to use this extension is the CP/M executable format, but I don't think too many of that are present in the wild these days: https://en.wikipedia.org/wiki/CMD_file_(CP/M)

I've found no other source of ambiguity.