### PR TITLE
Add support for *.diff

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -58,6 +58,7 @@ EXTENSIONS = {
     'dart': {'text', 'dart'},
     'dbc': {'text', 'dbc'},
     'def': {'text', 'def'},
+    'diff': {'text', 'diff'},
     'dll': {'binary'},
     'dtd': {'text', 'dtd'},
     'ear': {'binary', 'zip', 'jar'},


### PR DESCRIPTION
`identify` already supports `*.patch`, assigning it a `diff` tag. However, some people use `*.diff` as an extension instead of `*.patch`.

As far as I know, both extensions may contain various diff formats, and there's no official distinction between the two.

Stack Overflow answer saying the same: https://stackoverflow.com/a/4215933