### PR TITLE
Add GLSL file extensions

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -93,7 +93,7 @@ EXTENSIONS = {
     'ggb': {'binary', 'zip', 'ggb'},
     'gif': {'binary', 'image', 'gif'},
     'gleam': {'text', 'gleam'},
-    'glsl': {'comp', 'frag', 'geom', 'tesc', 'tese', 'vert'},
+    'glsl': {'text', 'comp', 'frag', 'geom', 'tesc', 'tese', 'vert'},
     'go': {'text', 'go'},
     'gotmpl': {'text', 'gotmpl'},
     'gpx': {'text', 'gpx', 'xml'},


### PR DESCRIPTION
Add [GLSL](https://github.com/KhronosGroup/GLSL) file extensions 'comp', 'frag', 'geom', 'tesc', 'tese', 'vert'.
See https://stackoverflow.com/questions/6432838/what-is-the-correct-file-extension-for-glsl-shaders/26531467#26531467