### PR TITLE
Configure pyproject.toml to have custom 'pyproject' file type

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -424,6 +424,7 @@ NAMES = {
     'poetry.lock': EXTENSIONS['toml'],
     'pom.xml': EXTENSIONS['pom'],
     'pylintrc': EXTENSIONS['ini'] | {'pylintrc'},
+    'pyproject.toml': EXTENSIONS['toml'] | {'pyproject'},
     'README': EXTENSIONS['txt'],
     'Rakefile': EXTENSIONS['rb'],
     'rebar.config': EXTENSIONS['erl'],


### PR DESCRIPTION
(Sorry not sure what the right terminology is.)

The main reason to do this is because `ruff` can lint the `pyproject.toml` file and it uses `types_or` to match files. If `ruff` were to match against 'toml' in its `types_or` it would match too many files. So the idea is to merge this then update ruff's hook definition to

```diff
 - id: ruff-check
   name: ruff check
   description: "Run 'ruff check' for extremely fast Python linting"
   entry: ruff check --force-exclude
   language: python
+  types_or: [python, pyi, jupyter, pyproject]
-  types_or: [python, pyi, jupyter]
```

I got this idea by looking at how jenkinfiles is defined; although it's a groovy file, it has a custom jenkinsfile-specific file type in this extensions file.