### PR TITLE
Add typ file extension for Typst files

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -285,6 +285,7 @@ EXTENSIONS = {
     'txsprofile': {'text', 'ini', 'txsprofile'},
     'txt': {'text', 'plain-text'},
     'txtpb': {'text', 'textproto'},
+    'typ': {'text', 'typst'},
     'urdf': {'text', 'xml', 'urdf'},
     'v': {'text', 'verilog'},
     'vb': {'text', 'vb'},


### PR DESCRIPTION
Typst is a modern typesetting system that tries to compete with e.g. Latex. `*.typ` is the recommended extension for typst files.

Information on Typst can be found here: https://github.com/typst/ and https://typst.app/