### PR TITLE
Add support for 'luau' file extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -163,6 +163,7 @@ EXTENSIONS = {
     'lpr': {'text', 'lazarus', 'pascal'},
     'lr': {'text', 'lektor'},
     'lua': {'text', 'lua'},
+    'luau': {'text', 'lua', 'luau'},
     'm': {'text', 'objective-c'},
     'm4': {'text', 'm4'},
     'magik': {'text', 'magik'},

--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -163,7 +163,7 @@ EXTENSIONS = {
     'lpr': {'text', 'lazarus', 'pascal'},
     'lr': {'text', 'lektor'},
     'lua': {'text', 'lua'},
-    'luau': {'text', 'lua', 'luau'},
+    'luau': {'text', 'luau'},
     'm': {'text', 'objective-c'},
     'm4': {'text', 'm4'},
     'magik': {'text', 'magik'},


### PR DESCRIPTION
Adds support for the `.luau` file extension, a filetype used most commonly around the Roblox ecosystem, as well as some standalone runtimes.

Hooks created for pre-commit (like [StyLua's](https://github.com/JohnnyMorganz/StyLua/blob/main/.pre-commit-hooks.yaml) from 5 years ago) are aimed at the "lua" type. Adding this allows for backwards compatibility.