### PR TITLE
Add TableGen Support

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -267,6 +267,7 @@ EXTENSIONS = {
     'tac': {'text', 'twisted', 'python'},
     'tar': {'binary', 'tar'},
     'targets': {'text', 'xml', 'msbuild'},
+    'td': {'text','tablegen'},
     'templ': {'text', 'templ'},
     'tex': {'text', 'tex'},
     'textproto': {'text', 'textproto'},

--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -267,7 +267,7 @@ EXTENSIONS = {
     'tac': {'text', 'twisted', 'python'},
     'tar': {'binary', 'tar'},
     'targets': {'text', 'xml', 'msbuild'},
-    'td': {'text','tablegen'},
+    'td': {'text', 'tablegen'},
     'templ': {'text', 'templ'},
     'tex': {'text', 'tex'},
     'textproto': {'text', 'textproto'},


### PR DESCRIPTION
This is LLVM's [TableGen](https://llvm.org/docs/TableGen/) DSL

TableGens seems to be supported by clang-format. So in theory once this is merged [pre-commit/mirrors-clang-format](https://github.com/pre-commit/mirrors-clang-format/blob/main/.pre-commit-hooks.yaml) should also be updated