### PR TITLE
Provide support for VALA language files

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -325,6 +325,7 @@ EXTENSIONS = {
     'xsd': {'text', 'xml', 'xsd'},
     'xsl': {'text', 'xml', 'xsl'},
     'xslt': {'text', 'xml', 'xsl'},
+    'vala': {'text', 'vala'},
     'yaml': {'text', 'yaml'},
     'yamlld': {'text', 'yaml', 'yamlld'},
     'yang': {'text', 'yang'},


### PR DESCRIPTION
This change adds file extension detection support for .vala files, which is used by the VALA programming language.

Closes:	#258

_(This is a resubmission of #549)_