### PR TITLE
feat: tag .build extension as bazel/starlark

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -23,6 +23,7 @@ EXTENSIONS = {
     'bz2': {'binary', 'bzip2'},
     'bz3': {'binary', 'bzip3'},
     'bzl': {'text', 'bazel'},
+    'build': {'text', 'bazel'},  # e.g. package.BUILD / foo.build (#103)
     'c': {'text', 'c'},
     'c++': {'text', 'c++'},
     'c++m': {'text', 'c++'},


### PR DESCRIPTION
## Summary
Recognize the `build` filename extension as Bazel/Starlark, so `package.build` / case-insensitive `*.BUILD` files are tagged (issue #103).

Fixes #103
